### PR TITLE
Remove requirements to call Eigen::initParallel

### DIFF
--- a/Eigen/src/Core/products/GeneralBlockPanelKernel.h
+++ b/Eigen/src/Core/products/GeneralBlockPanelKernel.h
@@ -27,13 +27,8 @@ inline std::ptrdiff_t manage_caching_sizes_helper(std::ptrdiff_t a, std::ptrdiff
 /** \internal */
 inline void manage_caching_sizes(Action action, std::ptrdiff_t* l1=0, std::ptrdiff_t* l2=0)
 {
-  static std::ptrdiff_t m_l1CacheSize = 0;
-  static std::ptrdiff_t m_l2CacheSize = 0;
-  if(m_l2CacheSize==0)
-  {
-    m_l1CacheSize = manage_caching_sizes_helper(queryL1CacheSize(),8 * 1024);
-    m_l2CacheSize = manage_caching_sizes_helper(queryTopLevelCacheSize(),1*1024*1024);
-  }
+  static std::ptrdiff_t m_l1CacheSize = manage_caching_sizes_helper(queryL1CacheSize(),8 * 1024);
+  static std::ptrdiff_t m_l2CacheSize = manage_caching_sizes_helper(queryTopLevelCacheSize(),1*1024*1024);
   
   if(action==SetAction)
   {

--- a/Eigen/src/Core/products/Parallelizer.h
+++ b/Eigen/src/Core/products/Parallelizer.h
@@ -17,12 +17,16 @@ namespace internal {
 /** \internal */
 inline void manage_multi_threading(Action action, int* v)
 {
+  #ifdef EIGEN_HAS_OPENMP
   static EIGEN_UNUSED int m_maxThreads = -1;
+  #endif
 
   if(action==SetAction)
   {
     eigen_internal_assert(v!=0);
+    #ifdef EIGEN_HAS_OPENMP
     m_maxThreads = *v;
+    #endif
   }
   else if(action==GetAction)
   {


### PR DESCRIPTION
Changed the way function level statics are initialized to avoid having to call Eigen::initParallel before any routines if Eigen are called from multiple threads.
